### PR TITLE
Lack of Cohesion between Methods

### DIFF
--- a/src/com/metricsassignment/Main.java
+++ b/src/com/metricsassignment/Main.java
@@ -4,6 +4,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.metricsassignment.metrics.CBOMetric;
+import com.metricsassignment.metrics.LCOMMetric;
+import com.metricsassignment.metrics.Metric;
+import com.metricsassignment.metrics.RFCMetric;
+import com.metricsassignment.metrics.WMCMetric;
+
 public class Main {
 
 	public static void main(String[] args) {
@@ -14,7 +20,7 @@ public class Main {
 		metrics.add(new WMCMetric());
 		//metrics.add(new RFCMetric());
 		//metrics.add(new CBOMetric());
-		//metrics.add(new LCOMMetric());
+		metrics.add(new LCOMMetric());
 
 		MetricReport mr = new MetricReport(file, metrics);
 		mr.print();

--- a/src/com/metricsassignment/MetricReport.java
+++ b/src/com/metricsassignment/MetricReport.java
@@ -28,16 +28,16 @@ public class MetricReport {
 	public void print() {
 		calculate();
 
-		System.out.printf("%-25s", "Class name");
+		System.out.printf("%-24s", "Class name");
 		for (Metric m : metrics)
-			System.out.printf("\t\t%7s", m.getClass().getSimpleName());
-
+			System.out.printf("%24s", m.getClass().getSimpleName());
 		System.out.print("\n");
+
 		for (Map.Entry<CompilationUnit, List<Double>> entry : report.entrySet()) {
 			String className = entry.getKey().getType(0).getNameAsString();
-			System.out.printf("%-25s", className);
+			System.out.printf("%-24s", className);
 			for (Double d : entry.getValue()) {
-				System.out.printf("\t\t%7.2f", d.doubleValue());
+				System.out.printf("\t\t%8.2f", d.doubleValue());
 			}
 			System.out.print("\n");
 		}

--- a/src/com/metricsassignment/MetricReport.java
+++ b/src/com/metricsassignment/MetricReport.java
@@ -25,6 +25,9 @@ public class MetricReport {
 		this.metrics = metrics;
 	}
 
+	/**
+	 * This method assumes that each class is in its own file.
+	 */
 	public void print() {
 		calculate();
 

--- a/src/com/metricsassignment/metrics/LCOMMetric.java
+++ b/src/com/metricsassignment/metrics/LCOMMetric.java
@@ -1,12 +1,57 @@
 package com.metricsassignment.metrics;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import com.github.javaparser.ast.CompilationUnit;
+
+import visitors.CouplingCountVisitor;
 
 // Lack of Cohesion of Methods
 public class LCOMMetric implements Metric {
+	
+	/**
+	 * p counts method pairs that don't share fields
+	 * q counts method pairs that share fields
+	 */
+	private int p = 0, q = 0;
 
     @Override
     public double calculate(CompilationUnit compilationUnit) {
-        return 1;
+    	List<Set<String>> fieldsSetList = new ArrayList<Set<String>>();
+    	new CouplingCountVisitor(fieldsSetList).visit(compilationUnit, null);
+    	considerAllPairs(fieldsSetList);
+        return p > q ? p - q : 0;
+    }
+
+    private void considerAllPairs(List<Set<String>> ls) {
+    	int n = ls.size();
+    	if(n == 2) {
+    		if(doesShareFields(ls.get(0), ls.get(1)))
+    			p++;
+    		else
+    			q++;
+    	}
+    	else if(n > 2) {
+    		Set<String> first = ls.get(0);
+    		List<Set<String>> newls = ls.subList(1, n);
+    		for( Set<String> s : newls) {
+    			if(doesShareFields(first, s))
+    				p++;
+    			else
+    				q++;
+    		}
+    		considerAllPairs(newls);
+    	}
+    		
+    }
+    
+    private boolean doesShareFields(Set<String> a, Set<String> b) {
+    	for(String s : a) {
+    		if(b.contains(s))
+    			return true;
+    	}
+		return false;
     }
 }

--- a/src/com/metricsassignment/metrics/LCOMMetric.java
+++ b/src/com/metricsassignment/metrics/LCOMMetric.java
@@ -15,13 +15,18 @@ public class LCOMMetric implements Metric {
 	 * p counts method pairs that don't share fields
 	 * q counts method pairs that share fields
 	 */
-	private int p = 0, q = 0;
+	private int p, q;
 
     @Override
     public double calculate(CompilationUnit compilationUnit) {
+    	p = 0; q = 0;
     	List<Set<String>> fieldsSetList = new ArrayList<Set<String>>();
     	new CouplingCountVisitor(fieldsSetList).visit(compilationUnit, null);
+    	//System.out.println("Full list: " + fieldsSetList);
+    	//System.out.println("Classname: " + compilationUnit.getType(0).getNameAsString());
     	considerAllPairs(fieldsSetList);
+    	int m = p + q;
+    	//System.out.println("Size: " + fieldsSetList.size() + ", Combinations: " + m + ", Shared method number: " + q);
         return p > q ? p - q : 0;
     }
 
@@ -29,18 +34,18 @@ public class LCOMMetric implements Metric {
     	int n = ls.size();
     	if(n == 2) {
     		if(doesShareFields(ls.get(0), ls.get(1)))
-    			p++;
-    		else
     			q++;
+    		else
+    			p++;
     	}
     	else if(n > 2) {
     		Set<String> first = ls.get(0);
     		List<Set<String>> newls = ls.subList(1, n);
     		for( Set<String> s : newls) {
     			if(doesShareFields(first, s))
-    				p++;
-    			else
     				q++;
+    			else
+    				p++;
     		}
     		considerAllPairs(newls);
     	}
@@ -48,6 +53,8 @@ public class LCOMMetric implements Metric {
     }
     
     private boolean doesShareFields(Set<String> a, Set<String> b) {
+    	//System.out.print(a + ", ");
+    	//System.out.println(b);
     	for(String s : a) {
     		if(b.contains(s))
     			return true;

--- a/src/visitors/CouplingCountVisitor.java
+++ b/src/visitors/CouplingCountVisitor.java
@@ -1,0 +1,96 @@
+package visitors;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+
+public class CouplingCountVisitor extends VoidVisitorAdapter<Boolean>{
+
+	/**
+	 * The set of fields of this class
+	 */
+	private Set<String> fieldSet;
+	/**
+	 * A working set of fields referred to in the current method being visited.
+	 */
+	private Set<String> workingFieldReferences;
+
+	/**
+	 * The list of fields referred by each method.
+	 */
+	private List<Set<String>> methodFieldsList;
+
+	public CouplingCountVisitor(List<Set<String>> methodFieldsList) {
+		this.methodFieldsList = methodFieldsList;
+		fieldSet = new HashSet<String>();
+	}
+
+
+	/*
+	 * Add each field to a list. 
+	 */
+	public void visit(FieldDeclaration n, Boolean arg) {
+		for(VariableDeclarator var : n.getVariables())
+			fieldSet.add(var.getNameAsString());
+	}
+
+	/*
+	 * We make sure we track visits to a method's body and consider that as one entry.
+	 */
+	@Override
+	public void visit(MethodDeclaration n, Boolean arg){
+		/*
+		 * We use the extra argument to tell further visits to record.
+		 */
+		arg = true;
+
+		workingFieldReferences = new HashSet<String>();
+		super.visit(n, arg);
+		if(workingFieldReferences.size() != 0)
+			methodFieldsList.add(workingFieldReferences);
+		//arg = false; coz source call has final param. Goes back to null
+	}
+
+	/*
+	 * Possible places where a field could be used:
+	 * * 
+	 * * FieldAccessExpr - only if the scope is a ThisExpr.Typename of the ThisExpr is ignored.
+	 * * NameExpr
+	 */
+
+	/**
+	 * This method will catch whenever the field names are used in a NameExpr.
+	 * NameExpr are used in assignments, method call parameters.
+	 * There is a specific case were 
+	 * a field name is used as a local parameter but not anything else.
+	 * This method would wrongly add that as a field reference.
+	 * For example, in a class with method {@code create(int a, int b)}
+	 * and field {@code private int b}, if the body of the method
+	 * uses the parameter and not the field, this visit method would still
+	 * wrongly count it. 
+	 */
+	@Override
+	public void visit(NameExpr n , Boolean arg) {
+			if(arg != null && fieldSet.contains(n.getNameAsString()))
+				workingFieldReferences.add(n.getNameAsString());
+	}
+	
+	/**
+	 * This method will catch usage of fields in expressions like {@code this.fieldname}
+	 * Any type names before {@code this} like {@code World} in {@code World.this.fieldname} are ignored.
+	 */
+	@Override
+	public void visit(FieldAccessExpr n, Boolean arg) {
+		if(arg != null && n.getScope() instanceof ThisExpr && fieldSet.contains(n.getNameAsString()))
+			workingFieldReferences.add(n.getNameAsString());
+	}
+}

--- a/src/visitors/CouplingCountVisitor.java
+++ b/src/visitors/CouplingCountVisitor.java
@@ -2,18 +2,18 @@ package visitors;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
-public class CouplingCountVisitor extends VoidVisitorAdapter<Boolean>{
+public class CouplingCountVisitor extends VoidVisitorAdapter<Void>{
 
 	/**
 	 * The set of fields of this class
@@ -29,35 +29,46 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Boolean>{
 	 */
 	private List<Set<String>> methodFieldsList;
 
+	/**
+	 * We use this to tell further visits to record.
+	 */
+	private boolean doRecord;
+	
+	/**
+	 * We use this to track parameter names
+	 */
+	private Set<String> params;
+	
 	public CouplingCountVisitor(List<Set<String>> methodFieldsList) {
 		this.methodFieldsList = methodFieldsList;
 		fieldSet = new HashSet<String>();
+		doRecord = false;
 	}
 
 
-	/*
+	/**
 	 * Add each field to a list. 
 	 */
-	public void visit(FieldDeclaration n, Boolean arg) {
+	public void visit(FieldDeclaration n, Void arg) {
 		for(VariableDeclarator var : n.getVariables())
 			fieldSet.add(var.getNameAsString());
 	}
 
-	/*
+	/**
 	 * We make sure we track visits to a method's body and consider that as one entry.
 	 */
 	@Override
-	public void visit(MethodDeclaration n, Boolean arg){
-		/*
-		 * We use the extra argument to tell further visits to record.
-		 */
-		arg = true;
-
+	public void visit(MethodDeclaration n, Void arg){
+		doRecord = true;
+		params = new HashSet<String>();
+		for(Parameter p : n.getParameters()) {
+			params.add(p.getNameAsString());
+		}
 		workingFieldReferences = new HashSet<String>();
-		super.visit(n, arg);
+		super.visit(n, null);
 		if(workingFieldReferences.size() != 0)
 			methodFieldsList.add(workingFieldReferences);
-		//arg = false; coz source call has final param. Goes back to null
+		doRecord = false;
 	}
 
 	/*
@@ -70,17 +81,10 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Boolean>{
 	/**
 	 * This method will catch whenever the field names are used in a NameExpr.
 	 * NameExpr are used in assignments, method call parameters.
-	 * There is a specific case were 
-	 * a field name is used as a local parameter but not anything else.
-	 * This method would wrongly add that as a field reference.
-	 * For example, in a class with method {@code create(int a, int b)}
-	 * and field {@code private int b}, if the body of the method
-	 * uses the parameter and not the field, this visit method would still
-	 * wrongly count it. 
 	 */
 	@Override
-	public void visit(NameExpr n , Boolean arg) {
-			if(arg != null && fieldSet.contains(n.getNameAsString()))
+	public void visit(NameExpr n , Void arg) {
+			if(doRecord && fieldSet.contains(n.getNameAsString()) && !params.contains(n.getNameAsString()))
 				workingFieldReferences.add(n.getNameAsString());
 	}
 	
@@ -89,8 +93,8 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Boolean>{
 	 * Any type names before {@code this} like {@code World} in {@code World.this.fieldname} are ignored.
 	 */
 	@Override
-	public void visit(FieldAccessExpr n, Boolean arg) {
-		if(arg != null && n.getScope() instanceof ThisExpr && fieldSet.contains(n.getNameAsString()))
+	public void visit(FieldAccessExpr n, Void arg) {
+		if(doRecord && n.getScope() instanceof ThisExpr && fieldSet.contains(n.getNameAsString()))
 			workingFieldReferences.add(n.getNameAsString());
 	}
 }

--- a/src/visitors/CouplingCountVisitor.java
+++ b/src/visitors/CouplingCountVisitor.java
@@ -33,12 +33,12 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Void>{
 	 * We use this to tell further visits to record.
 	 */
 	private boolean doRecord;
-	
+
 	/**
 	 * We use this to track parameter names
 	 */
 	private Set<String> params;
-	
+
 	public CouplingCountVisitor(List<Set<String>> methodFieldsList) {
 		this.methodFieldsList = methodFieldsList;
 		fieldSet = new HashSet<String>();
@@ -84,10 +84,11 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Void>{
 	 */
 	@Override
 	public void visit(NameExpr n , Void arg) {
-			if(doRecord && fieldSet.contains(n.getNameAsString()) && !params.contains(n.getNameAsString()))
-				workingFieldReferences.add(n.getNameAsString());
+		if(doRecord && fieldSet.contains(n.getNameAsString()) && !params.contains(n.getNameAsString()))
+			workingFieldReferences.add(n.getNameAsString());
+		super.visit(n, null);
 	}
-	
+
 	/**
 	 * This method will catch usage of fields in expressions like {@code this.fieldname}
 	 * Any type names before {@code this} like {@code World} in {@code World.this.fieldname} are ignored.
@@ -96,5 +97,6 @@ public class CouplingCountVisitor extends VoidVisitorAdapter<Void>{
 	public void visit(FieldAccessExpr n, Void arg) {
 		if(doRecord && n.getScope() instanceof ThisExpr && fieldSet.contains(n.getNameAsString()))
 			workingFieldReferences.add(n.getNameAsString());
+		super.visit(n, null);
 	}
 }


### PR DESCRIPTION
This implementation should correctly identify usage of field identifiers within methods. Situations where method parameter with names same as field names are used within methods should be correctly ignored.
If, however, an accessor method is used instead of directly using fieldname, this implementation possible wrongly ignores that instance.
